### PR TITLE
Remove request cloning to avoid duplicated requests

### DIFF
--- a/lib/snowplow-worker.js
+++ b/lib/snowplow-worker.js
@@ -3740,7 +3740,8 @@ class SnowplowWorker extends EventEmitter {
   fetchHandler (request) {
     let parsedURL = URLUtils.ParseURI(request.url);
 
-    if (this.collectorHosts.includes(parsedURL.host)) {
+    // TODO: Remove GET restriction once logic is in place to handle non-GET requests
+    if (this.collectorHosts.includes(parsedURL.host) && request.method === 'GET') {
       this.validateRequest(request);
     }
   }
@@ -3811,8 +3812,12 @@ class SnowplowWorker extends EventEmitter {
   _onFetch (event) {
     this.fetchHandler(event.request);
 
+    // TODO: This method assumes that fetchHandler does not read the body
+    //       of the request. This is ok, in the case of GET-based trackers
+    //       but wont work for other methods. Some logic is needed here to
+    //       conditionally clone requests if the given request is consumed.
     // Return the original response object, which will be used to fulfill the resource request.
-    return fetch(event.request.clone()).then((response) => response);
+    return fetch(event.request).then((response) => response);
   }
 
   _onMessage (event) {

--- a/src/service-worker/snowplow-worker.js
+++ b/src/service-worker/snowplow-worker.js
@@ -144,7 +144,8 @@ class SnowplowWorker extends EventEmitter {
   fetchHandler (request) {
     let parsedURL = URLUtils.ParseURI(request.url);
 
-    if (this.collectorHosts.includes(parsedURL.host)) {
+    // TODO: Remove GET restriction once logic is in place to handle non-GET requests
+    if (this.collectorHosts.includes(parsedURL.host) && request.method === 'GET') {
       this.validateRequest(request);
     }
   }
@@ -215,8 +216,12 @@ class SnowplowWorker extends EventEmitter {
   _onFetch (event) {
     this.fetchHandler(event.request);
 
+    // TODO: This method assumes that fetchHandler does not read the body
+    //       of the request. This is ok, in the case of GET-based trackers
+    //       but wont work for other methods. Some logic is needed here to
+    //       conditionally clone requests if the given request is consumed.
     // Return the original response object, which will be used to fulfill the resource request.
-    return fetch(event.request.clone()).then((response) => response);
+    return fetch(event.request).then((response) => response);
   }
 
   _onMessage (event) {


### PR DESCRIPTION
One must be careful when cloning requests, apparently.

The body of a Request object is consumable. Presumably (though I haven't research enough to know), reading the body of a request consumes the body and thus terminates the request (since reading the body would be required to send it over the network).

I had initially based the proxying of our requests based on some example code but I was too naive to realize that if the body of the original request were not consumed, it seems that "propagation" of the request would continue. In our case, the tracker requests are only GET requests and thus have no body (and thus no reading of the body is necessary). In practice we observed some duplicated POST events so non-collector endpoint so for safety I have restricted the worker to GET requests and disabled request cloning.

There are some TODOs in the code mentioning this as well and it should be taken as a future work item to add support for tracker requests with a body.
